### PR TITLE
delete String function

### DIFF
--- a/namespace.go
+++ b/namespace.go
@@ -77,10 +77,6 @@ func (n Namespace) FullName() string {
 	return n.name
 }
 
-func (n Namespace) String() string {
-	return n.name
-}
-
 // Parent returns the immediate parent namespace, if present.
 // The use of this function outside of a system layer that handles error types (see TypeSubscriber) is a code smell.
 func (n Namespace) Parent() *Namespace {


### PR DESCRIPTION
Hello. 
I has a doubt about the String function of namespace.go .Since processing with this function is made by FullName () function, I felt it was not necessary. I deleted the String() function and tested it, but I passed.