### PR TITLE
Feature/immutability

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -78,6 +78,9 @@ func TestImmutableError(t *testing.T) {
 		err1 := err.WithProperty(PropertyPayload(), 1)
 		err2 := err1.WithProperty(PropertyPayload(), 2)
 
+		require.True(t, err.errorType.IsOfType(err2.errorType))
+		require.Equal(t, err.message, err2.message)
+
 		payload, ok := ExtractPayload(err)
 		require.False(t, ok)
 
@@ -94,6 +97,9 @@ func TestImmutableError(t *testing.T) {
 		err := testType.NewWithNoMessage()
 		err1 := err.WithUnderlyingErrors(testSubtype0.NewWithNoMessage())
 		err2 := err1.WithUnderlyingErrors(testSubtype1.NewWithNoMessage())
+
+		require.True(t, err.errorType.IsOfType(err2.errorType))
+		require.Equal(t, err.message, err2.message)
 
 		require.Len(t, err.underlying, 0)
 		require.Len(t, err1.underlying, 1)

--- a/error_test.go
+++ b/error_test.go
@@ -72,6 +72,35 @@ func TestErrorMessages(t *testing.T) {
 	})
 }
 
+func TestImmutableError(t *testing.T) {
+	t.Run("Property", func(t *testing.T) {
+		err := testType.NewWithNoMessage()
+		err1 := err.WithProperty(PropertyPayload(), 1)
+		err2 := err1.WithProperty(PropertyPayload(), 2)
+
+		payload, ok := ExtractPayload(err)
+		require.False(t, ok)
+
+		payload, ok = ExtractPayload(err1)
+		require.True(t, ok)
+		require.EqualValues(t, 1, payload)
+
+		payload, ok = ExtractPayload(err2)
+		require.True(t, ok)
+		require.EqualValues(t, 2, payload)
+	})
+
+	t.Run("Underlying", func(t *testing.T) {
+		err := testType.NewWithNoMessage()
+		err1 := err.WithUnderlyingErrors(testSubtype0.NewWithNoMessage())
+		err2 := err1.WithUnderlyingErrors(testSubtype1.NewWithNoMessage())
+
+		require.Len(t, err.underlying, 0)
+		require.Len(t, err1.underlying, 1)
+		require.Len(t, err2.underlying, 2)
+	})
+}
+
 func TestErrorStackTrace(t *testing.T) {
 	err := createErrorFuncInStackTrace(testType)
 	output := fmt.Sprintf("%+v", err)


### PR DESCRIPTION
As it stands, error is not goroutiune-safe due to a couple of mutable fields.
With this PR, a copying strategy is implemented. The overhead is expected to be low, as these modifications are rare in practice. 