### PR TITLE
GetAllPrintableProperties will return a map of all printable properties

### DIFF
--- a/error.go
+++ b/error.go
@@ -213,17 +213,9 @@ func (e *Error) messageFromProperties() string {
 	if e.printablePropertyCount == 0 {
 		return ""
 	}
-	uniq := make(map[Property]struct{}, e.printablePropertyCount)
 	strs := make([]string, 0, e.printablePropertyCount)
-	for m := e.properties; m != nil; m = m.next {
-		if !m.p.printable {
-			continue
-		}
-		if _, ok := uniq[m.p]; ok {
-			continue
-		}
-		uniq[m.p] = struct{}{}
-		strs = append(strs, fmt.Sprintf("%s: %v", m.p.label, m.value))
+	for k, v := range e.GetAllPrintableProperties() {
+		strs = append(strs, fmt.Sprintf("%s: %v", k, v))
 	}
 	return "{" + strings.Join(strs, ", ") + "}"
 }
@@ -270,4 +262,18 @@ func joinStringsIfNonEmpty(delimiter string, parts ...string) string {
 
 		return strings.Join(filteredParts, delimiter)
 	}
+}
+
+func (e *Error) GetAllPrintableProperties() map[string]interface{} {
+	uniq := make(map[string]interface{}, e.printablePropertyCount)
+	for m := e.properties; m != nil; m = m.next {
+		if !m.p.printable {
+			continue
+		}
+		if _, ok := uniq[m.p.label]; ok {
+			continue
+		}
+		uniq[m.p.label] = m.value
+	}
+	return uniq
 }


### PR DESCRIPTION
As discussed in #21, we can simply move some of the code and create a method corresponding to current logic to expose all properties from the error for further processing of errors in situations one would to use them in REST APIs and such.

Simple code like the one below can cover creating a struct from `errorx.Error`:

```golang
type ErrorJson struct {
	Message    string                 `json:"message"`
	Properties map[string]interface{} `json:"properties,omitempty"`
	Cause      interface{}            `json:"cause,omitempty"`
}

func SimpleConvertToStruct(e error) *ErrorJson {
	if e != nil {
		if err := errorx.Cast(e); err != nil {
			result :=  &ErrorJson{
				Message:    err.Message(),
				Properties: err.GetAllPrintableProperties(),
			}
			if err.Cause() != nil {
				result.Cause = SimpleConvertToStruct(err.Cause())
			}
			return result
		} else {
			return &ErrorJson{
				Message: e.Error(),
			}
		}
	} else {
		return nil
	}
}
```

This can be used to create a JSON returned to the end customer as an error message. But the code above is *just* an example, not a production-ready code! Please, review and test before using it as I haven't at all!

