### PR TITLE
Add helper methods for the "errors" package

### DIFF
--- a/errors_113.go
+++ b/errors_113.go
@@ -1,0 +1,70 @@
+// This file implements the helper interfaces for the errors package introduced in Go 1.13
+// +build go1.13
+
+package errorx
+
+import "errors"
+
+// As implements the helper interface for errors.As.
+// If v is a pointer to a pointer to Error, *v will be set to this error.
+// Otherwise, it traverses the error chain until it reaches a non-*Error error and calls errors.As on that error and the
+// target.
+func (e *Error) As(v interface{}) bool {
+	if target, ok := v.(**Error); ok {
+		*target = e
+		return true
+	}
+
+	cause := e
+	for cause != nil {
+		next := cause.Cause()
+		cause = Cast(next)
+		if cause == nil && next != nil {
+			return errors.As(next, v)
+		}
+	}
+	return false
+}
+
+// Is implements the helper interface for errors.Is.
+// If target is an *Error, we check each non-transparent Error in the error chain and compare the types using IsOfType.
+// If target is not an *Error, we traverse the error chain until we reach a non-Error error and use errors.Is to check
+// if that error Is the same as the target error.
+func (e *Error) Is(target error) bool {
+	var t *Type
+	if cast := Cast(target); cast != nil {
+		t = cast.Type()
+	}
+
+	cause := e
+	for cause != nil {
+		if t != nil && !cause.transparent && cause.errorType.IsOfType(t) {
+			return true
+		}
+		next := cause.Cause()
+		cause = Cast(next)
+		// We check if t == nil as well because a non-Error error will fail the errors.Is check anyways if target is
+		// an Error.
+		if t == nil && cause == nil && next != nil {
+			return errors.Is(next, target)
+		}
+	}
+	return false
+}
+
+// Unwrap implements the helper interface for errors.Unwrap.
+// It will return the first, non-transparent error in the error chain, or the final error if it is not an *Error.
+// It is not an inversion of the Wrap method.
+func (e *Error) Unwrap() error {
+	cause := e
+	for cause != nil {
+		next := cause.Cause()
+		cause = Cast(next)
+		if cause == nil {
+			return next
+		} else if !cause.transparent {
+			return cause
+		}
+	}
+	return nil
+}

--- a/errors_113_test.go
+++ b/errors_113_test.go
@@ -1,0 +1,161 @@
+// +build go1.13
+
+package errorx
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type otherError struct {
+	message string
+}
+
+func (e *otherError) Error() string {
+	return e.message
+}
+
+func TestErrorsIs(t *testing.T) {
+	errInner := testType.NewWithNoMessage()
+
+	t.Run("Wrap", func(t *testing.T) {
+		err0 := testTypeBar1.Wrap(errInner, "a")
+
+		require.True(t, errors.Is(err0, errInner))
+		require.True(t, err0.Is(errInner))
+
+		err1 := testTypeBar1.NewWithNoMessage()
+		require.False(t, errors.Is(err1, errInner))
+		require.False(t, err1.Is(errInner))
+
+		err2 := testTypeBar2.WrapWithNoMessage(err1)
+		require.False(t, errors.Is(err2, errInner))
+		require.False(t, err2.Is(errInner))
+		require.True(t, errors.Is(err2, err1))
+		require.True(t, err2.Is(err1))
+
+		err3 := testTypeTransparent.WrapWithNoMessage(testTypeBar1.NewWithNoMessage())
+		err4 := testTypeTransparent.WrapWithNoMessage(testTypeBar2.NewWithNoMessage())
+		require.False(t, errors.Is(err3, err4))
+		require.False(t, err3.Is(err4))
+		require.False(t, errors.Is(err4, err3))
+		require.False(t, err4.Is(err3))
+	})
+
+	t.Run("Decorate", func(t *testing.T) {
+		err1 := testTypeBar1.Wrap(errInner, "a")
+		err2 := Decorate(err1, "b")
+
+		require.True(t, errors.Is(err2, err1))
+		require.True(t, err2.Is(err1))
+		require.True(t, errors.Is(err2, errInner))
+		require.True(t, err2.Is(errInner))
+	})
+
+	t.Run("Builtins", func(t *testing.T) {
+		err0 := testType.WrapWithNoMessage(context.Canceled)
+		err1 := testTypeBar1.WrapWithNoMessage(err0)
+
+		require.True(t, errors.Is(err0, context.Canceled))
+		require.True(t, err0.Is(context.Canceled))
+		require.True(t, errors.Is(err1, context.Canceled))
+		require.True(t, err1.Is(context.Canceled))
+	})
+}
+
+func TestErrorsAs(t *testing.T) {
+	t.Run("errorx.Error", func(t *testing.T) {
+		errInner := testType.NewWithNoMessage()
+		err0 := testTypeBar1.Wrap(errInner, "a")
+		err1 := testTypeBar2.Wrap(err0, "b")
+
+		var e0 *Error
+		require.True(t, errors.As(err0, &e0))
+		require.Equal(t, e0.message, err0.message)
+		require.True(t, errors.Is(e0, errInner))
+
+		var e2 *Error
+		require.True(t, err0.As(&e2))
+		require.Equal(t, e2.message, err0.message)
+		require.True(t, errors.Is(e2, errInner))
+
+		var e3 *Error
+		require.True(t, errors.As(err1, &e3))
+		require.Equal(t, e3.message, err1.message)
+		require.True(t, errors.Is(e3, errInner))
+
+		var e4 *Error
+		require.True(t, err1.As(&e4))
+		require.Equal(t, e4.message, err1.message)
+		require.True(t, errors.Is(e4, errInner))
+	})
+
+	t.Run("OtherError", func(t *testing.T) {
+		errOther := &otherError{message: "foo"}
+		err := testType.WrapWithNoMessage(errOther)
+
+		var oe0 *otherError
+		require.True(t, errors.As(err, &oe0))
+		require.Equal(t, oe0.message, errOther.message)
+
+		var oe1 *otherError
+		require.True(t, err.As(&oe1))
+		require.Equal(t, oe1.message, errOther.message)
+	})
+}
+
+func TestErrorUnwrap(t *testing.T) {
+	errInner := testType.NewWithNoMessage()
+
+	t.Run("Wrap", func(t *testing.T) {
+		err := testTypeBar1.Wrap(errInner, "a")
+
+		unwrapped := errors.Unwrap(err)
+		require.True(t, errors.Is(unwrapped, errInner))
+		require.False(t, errors.Is(unwrapped, err))
+
+		unwrapped = err.Unwrap()
+		require.True(t, errors.Is(unwrapped, errInner))
+		require.False(t, errors.Is(unwrapped, err))
+	})
+
+	t.Run("Decorate", func(t *testing.T) {
+		err0 := testTypeBar1.Wrap(errInner, "a")
+		err1 := Decorate(err0, "b")
+
+		unwrapped := errors.Unwrap(err1)
+		require.True(t, errors.Is(unwrapped, err0))
+		require.True(t, errors.Is(unwrapped, errInner))
+
+		unwrapped = err1.Unwrap()
+		require.True(t, errors.Is(unwrapped, err0))
+		require.True(t, errors.Is(unwrapped, errInner))
+	})
+
+	t.Run("Builtins", func(t *testing.T) {
+		err0 := testType.WrapWithNoMessage(context.Canceled)
+		err1 := testTypeBar1.WrapWithNoMessage(context.Canceled)
+		err2 := testTypeTransparent.WrapWithNoMessage(context.Canceled)
+		err3 := testTypeTransparent.WrapWithNoMessage(err1)
+
+		require.Equal(t, context.Canceled, errors.Unwrap(err0))
+		require.Equal(t, context.Canceled, err0.Unwrap())
+		require.Equal(t, context.Canceled, errors.Unwrap(err1))
+		require.Equal(t, context.Canceled, err1.Unwrap())
+		require.Equal(t, context.Canceled, errors.Unwrap(err2))
+		require.Equal(t, context.Canceled, err2.Unwrap())
+
+		err3Unwrapped := Cast(errors.Unwrap(err3))
+		require.NotNil(t, err3Unwrapped)
+		require.True(t, err3Unwrapped.IsOfType(err1.Type()))
+		require.True(t, errors.Is(err3Unwrapped, context.Canceled))
+
+		err3Unwrapped = Cast(err3.Unwrap())
+		require.NotNil(t, err3Unwrapped)
+		require.True(t, err3Unwrapped.IsOfType(err1.Type()))
+		require.True(t, errors.Is(err3Unwrapped, context.Canceled))
+	})
+}

--- a/namespace_test.go
+++ b/namespace_test.go
@@ -40,7 +40,6 @@ func TestSubNamespace(t *testing.T) {
 	require.True(t, nsTest1Child.IsNamespaceOf(nsTestChild1ETChild))
 }
 
-
 func TestRootNamespace(t *testing.T) {
 	require.Equal(t, nsTest1, nsTestChild1ET.NewWithNoMessage().Type().RootNamespace())
 }


### PR DESCRIPTION
~This just calls 'Error.Cause()' but allows the `Error`s to interop with the 'errors' package from the Go standard library.  The main benefit is you can use 'errors.Is' to see if an Error was due to some standard error like context.Canceled.~

~Add an `Is` method to `*Error`.  This is the helper method for `errors.Is` so you can use that to check your errors.  It uses `Error.IsOfType` if it can (when `target` is an `*Error`), otherwise it falls back to iterating through the error chain until it reaches a non-`*Error` error and calls `errors.Is` against that error.~

Add **all** of the helper methods for the "errors" package behind a build flag so they are only available for Go 1.13+.