### PR TITLE
Make errors.As work for errorx

### DIFF
--- a/as.go
+++ b/as.go
@@ -2,6 +2,7 @@ package errorx
 
 import "fmt"
 
+// todo godoc
 type typeCheckTarget struct {
 	err *Error
 	assignabilityBlocker interface{}

--- a/as.go
+++ b/as.go
@@ -1,0 +1,22 @@
+package errorx
+
+import "fmt"
+
+type typeCheckTarget struct {
+	err *Error
+	assignabilityBlocker interface{}
+}
+
+func (t typeCheckTarget) Error() string {
+	return t.err.Error()
+}
+
+func (t typeCheckTarget) Format(s fmt.State, verb rune) {
+	t.err.Format(s, verb)
+}
+
+func (t *typeCheckTarget) AsError() *Error {
+	return t.err
+}
+
+var _ error = typeCheckTarget{}

--- a/as_test.go
+++ b/as_test.go
@@ -1,0 +1,12 @@
+package errorx
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAsWrapper(t *testing.T) {
+	require.False(t, reflect.TypeOf(Error{}).AssignableTo(reflect.TypeOf(typeCheckTarget{})))
+}

--- a/error_113.go
+++ b/error_113.go
@@ -2,6 +2,38 @@
 
 package errorx
 
+import "reflect"
+
+// todo add errorx.As()?
+// todo make another 'go error type' for passing into errors.As()?
+// todo when fixed, add tests for wrap/decorate etc.
+// As checks if target is of the same type as current error and, if true, sets target to this error value.
+// NB: Call to errors.As() converts any type of errorx error to any other type,
+// therefore such calls are currently unsafe for errorx errors and will likely break semantics.
+// Note than calls to errors.Is() do not suffer from the same issue.
+func (e *Error) As(target interface{}) bool {
+	targetWrapper, wrapperOk := target.(*typeCheckTarget)
+	if wrapperOk && !e.Is(targetWrapper.err) {
+		return false
+	}
+	if !wrapperOk  {
+		targetError, ok := target.(*error)
+		if !ok || !e.Is(*targetError) {
+			return false
+		}
+	}
+
+	if wrapperOk {
+		targetVal := reflect.ValueOf(targetWrapper.err)
+		targetVal.Elem().Set(reflect.ValueOf(*e))
+	} else {
+		targetVal := reflect.ValueOf(target)
+		targetVal.Elem().Set(reflect.ValueOf(e))
+	}
+
+	return true
+}
+
 // Is returns true if and only if target is errorx error that passes errorx type check against current error.
 // This behaviour is exactly the same as that of IsOfType().
 // See also: errors.Is()

--- a/error_113.go
+++ b/error_113.go
@@ -4,6 +4,7 @@ package errorx
 
 import "reflect"
 
+// todo godoc
 // As checks if target is of the same type as current error and, if true, sets target to this error value.
 // NB: Call to errors.As() converts any type of errorx error to any other type,
 // therefore such calls are currently unsafe for errorx errors and will likely break semantics.

--- a/error_113.go
+++ b/error_113.go
@@ -4,9 +4,6 @@ package errorx
 
 import "reflect"
 
-// todo add errorx.As()?
-// todo make another 'go error type' for passing into errors.As()?
-// todo when fixed, add tests for wrap/decorate etc.
 // As checks if target is of the same type as current error and, if true, sets target to this error value.
 // NB: Call to errors.As() converts any type of errorx error to any other type,
 // therefore such calls are currently unsafe for errorx errors and will likely break semantics.
@@ -23,15 +20,24 @@ func (e *Error) As(target interface{}) bool {
 		}
 	}
 
+	// todo simplify flow
 	if wrapperOk {
-		targetVal := reflect.ValueOf(targetWrapper.err)
-		targetVal.Elem().Set(reflect.ValueOf(*e))
+		cause := e
+		for cause != nil {
+			// todo make direct use of errorType here more clear
+			if cause.errorType.IsOfType(targetWrapper.err.errorType) {
+				targetVal := reflect.ValueOf(targetWrapper.err)
+				targetVal.Elem().Set(reflect.ValueOf(*cause))
+				return true
+			}
+			cause = Cast(cause.Cause())
+		}
+		return false
 	} else {
 		targetVal := reflect.ValueOf(target)
 		targetVal.Elem().Set(reflect.ValueOf(e))
+		return true
 	}
-
-	return true
 }
 
 // Is returns true if and only if target is errorx error that passes errorx type check against current error.

--- a/error_113_test.go
+++ b/error_113_test.go
@@ -4,6 +4,7 @@ package errorx
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -102,3 +103,61 @@ func TestErrorIs(t *testing.T) {
 	})
 }
 
+func TestErrorAs(t *testing.T) {
+	t.Run("Trivial", func(t *testing.T) {
+		err := fooReturnsError()
+		target := testType.NewWithNoMessage()
+		require.True(t, errors.As(err, &target))
+		require.EqualValues(t, "whoops", target.Message())
+		output := fmt.Sprintf("%+v", target)
+		require.Contains(t, output, "fooReturnsError", output)
+	})
+
+	t.Run("TypeChecker", func(t *testing.T) {
+		err := fooReturnsError()
+		target := testType.ForTypeCheck()
+		require.True(t, errors.As(err, &target))
+		require.EqualValues(t, "whoops", target.AsError().Message())
+		output := fmt.Sprintf("%+v", target)
+		require.Contains(t, output, "fooReturnsError", output)
+	})
+
+	// Current errors.As allows no customization in this behaviour; if go types are assignable, here we go
+	t.Run("NegativeBroken", func(t *testing.T) {
+		err := fooReturnsError()
+		target := testTypeBar1.NewWithNoMessage()
+		require.True(t, errors.As(err, &target))
+		require.EqualValues(t, "whoops", target.Message())
+		require.True(t, IsOfType(target, testType))
+		require.False(t, IsOfType(target, testTypeBar1))
+	})
+
+	t.Run("NegativeFixed", func(t *testing.T) {
+		err := fooReturnsError()
+		target := testTypeBar1.ForTypeCheck()
+		require.False(t, errors.As(err, &target))
+	})
+
+	t.Run("Negative", func(t *testing.T) {
+		err := io.EOF
+		target := testTypeBar1.NewWithNoMessage()
+		require.False(t, errors.As(err, &target))
+	})
+
+	t.Run("DecorateForeign", func(t *testing.T) {
+		err := Decorate(myErr("test"),"")
+		var target myErr
+		require.True(t, errors.As(err, &target))
+		require.EqualValues(t, "test", target.Error())
+	})
+}
+
+func fooReturnsError() error {
+	return testType.New("whoops")
+}
+
+type myErr string
+
+func (e myErr) Error() string {
+	return string(e)
+}

--- a/type.go
+++ b/type.go
@@ -74,7 +74,8 @@ func (t *Type) WrapWithNoMessage(err error) *Error {
 		Create()
 }
 
-func (t *Type) ForTypeCheck() typeCheckTarget {
+// todo godoc
+func (t *Type) ForTypeCheck() typeCheckTarget { // todo inspecton
 	return typeCheckTarget{err: t.NewWithNoMessage()}
 }
 

--- a/type.go
+++ b/type.go
@@ -74,6 +74,10 @@ func (t *Type) WrapWithNoMessage(err error) *Error {
 		Create()
 }
 
+func (t *Type) ForTypeCheck() typeCheckTarget {
+	return typeCheckTarget{err: t.NewWithNoMessage()}
+}
+
 // IsOfType is a type check for error.
 // Returns true either if both are of exactly the same type, or if the same is true for one of current type's ancestors.
 func (t *Type) IsOfType(other *Type) bool {


### PR DESCRIPTION
This PR at this stage is more a design review than a code review. I did not do any code polishing until we agree on whether or not this idea is OK and what to change about it. 
A concept is simple: if an opinionated `errors.As` implementation prioritises assignability, let's remove it. A special wrapper is introduced in order to beat this, and `*Error::Is()` can then do its magic. If a wrapper is then used directly, it works as an `error` implementation, too.
If we go this way, I would also suggest to panic if errorx error is passed as target directly. Such cases are always intentional and by errorx user, so it seems like a good idea not to allow a broken usage at all. 