### PR TITLE
Use go 1.13 features to improve IsOfType checks

### DIFF
--- a/error.go
+++ b/error.go
@@ -103,22 +103,6 @@ func (e *Error) HasTrait(key Trait) bool {
 	return false
 }
 
-// IsOfType is a proper type check for an errorx-based errors.
-// It takes the transparency and error types hierarchy into account,
-// so that type check against any supertype of the original cause passes.
-func (e *Error) IsOfType(t *Type) bool {
-	cause := e
-	for cause != nil {
-		if !cause.transparent {
-			return cause.errorType.IsOfType(t)
-		}
-
-		cause = Cast(cause.Cause())
-	}
-
-	return false
-}
-
 // Type returns the exact type of this error.
 // With transparent wrapping, such as in Decorate(), returns the type of the original cause.
 // The result is always not nil, even if the resulting type is impossible to successfully type check against.

--- a/error.go
+++ b/error.go
@@ -103,6 +103,14 @@ func (e *Error) HasTrait(key Trait) bool {
 	return false
 }
 
+// IsOfType is a proper type check for an errorx-based errors.
+// It takes the transparency and error types hierarchy into account,
+// so that type check against any supertype of the original cause passes.
+// Go 1.13 and above: it also tolerates non-errorx errors in chain if those errors support errors unwrap.
+func (e *Error) IsOfType(t *Type) bool {
+	return e.isOfType(t)
+}
+
 // Type returns the exact type of this error.
 // With transparent wrapping, such as in Decorate(), returns the type of the original cause.
 // The result is always not nil, even if the resulting type is impossible to successfully type check against.

--- a/error_112.go
+++ b/error_112.go
@@ -2,18 +2,12 @@
 
 package errorx
 
-// IsOfType is a type check for errors.
-// Returns true either if both are of exactly the same type, or if the same is true for one of current type's ancestors.
-// For an error that does not have an errorx type, returns false.
-func IsOfType(err error, t *Type) bool {
+func isOfType(err error, t *Type) bool {
 	e := Cast(err)
 	return e != nil && e.IsOfType(t)
 }
 
-// IsOfType is a proper type check for an errorx-based errors.
-// It takes the transparency and error types hierarchy into account,
-// so that type check against any supertype of the original cause passes.
-func (e *Error) IsOfType(t *Type) bool {
+func (e *Error) isOfType(t *Type) bool {
 	cause := e
 	for cause != nil {
 		if !cause.transparent {

--- a/error_112.go
+++ b/error_112.go
@@ -1,0 +1,29 @@
+// +build !go1.13
+
+package errorx
+
+// IsOfType is a type check for errors.
+// Returns true either if both are of exactly the same type, or if the same is true for one of current type's ancestors.
+// For an error that does not have an errorx type, returns false.
+func IsOfType(err error, t *Type) bool {
+	e := Cast(err)
+	return e != nil && e.IsOfType(t)
+}
+
+// IsOfType is a proper type check for an errorx-based errors.
+// It takes the transparency and error types hierarchy into account,
+// so that type check against any supertype of the original cause passes.
+func (e *Error) IsOfType(t *Type) bool {
+	cause := e
+	for cause != nil {
+		if !cause.transparent {
+			return cause.errorType.IsOfType(t)
+		}
+
+		cause = Cast(cause.Cause())
+	}
+
+	return false
+}
+
+

--- a/error_113.go
+++ b/error_113.go
@@ -4,20 +4,12 @@ package errorx
 
 import "errors"
 
-// IsOfType is a type check for errors.
-// Returns true either if both are of exactly the same type, or if the same is true for one of current type's ancestors.
-// For an error that does not have an errorx type, returns false unless it wraps another error of errorx type.
-func IsOfType(err error, t *Type) bool {
+func isOfType(err error, t *Type) bool {
 	e := burrowForTyped(err)
 	return e != nil && e.IsOfType(t)
 }
 
-
-// IsOfType is a proper type check for an errorx-based errors.
-// It takes the transparency and error types hierarchy into account,
-// so that type check against any supertype of the original cause passes.
-// It also tolerates non-errorx errors in chain if those errors support go 1.13 errors unwrap.
-func (e *Error) IsOfType(t *Type) bool {
+func (e *Error) isOfType(t *Type) bool {
 	cause := e
 	for cause != nil {
 		if !cause.transparent {
@@ -44,5 +36,3 @@ func burrowForTyped(err error) *Error {
 
 	return nil
 }
-
-

--- a/error_113.go
+++ b/error_113.go
@@ -1,0 +1,46 @@
+// +build go1.13
+
+package errorx
+
+import "errors"
+
+// IsOfType is a type check for errors.
+// Returns true either if both are of exactly the same type, or if the same is true for one of current type's ancestors.
+// For an error that does not have an errorx type, returns false.
+func IsOfType(err error, t *Type) bool {
+	e := burrowForTyped(err)
+	return e != nil && e.IsOfType(t)
+}
+
+
+// IsOfType is a proper type check for an errorx-based errors.
+// It takes the transparency and error types hierarchy into account,
+// so that type check against any supertype of the original cause passes.
+func (e *Error) IsOfType(t *Type) bool {
+	cause := e
+	for cause != nil {
+		if !cause.transparent {
+			return cause.errorType.IsOfType(t)
+		}
+
+		cause = burrowForTyped(cause.Cause())
+	}
+
+	return false
+}
+
+func burrowForTyped(err error) *Error {
+	raw := err
+	for raw != nil {
+		typed := Cast(raw)
+		if typed != nil {
+			return typed
+		}
+
+		raw = errors.Unwrap(raw)
+	}
+
+	return nil
+}
+
+

--- a/error_113.go
+++ b/error_113.go
@@ -29,6 +29,7 @@ func (e *Error) IsOfType(t *Type) bool {
 	return false
 }
 
+// burrowForTyped returns either the first *Error in unwrap chain or nil
 func burrowForTyped(err error) *Error {
 	raw := err
 	for raw != nil {

--- a/error_113.go
+++ b/error_113.go
@@ -6,7 +6,7 @@ import "errors"
 
 // IsOfType is a type check for errors.
 // Returns true either if both are of exactly the same type, or if the same is true for one of current type's ancestors.
-// For an error that does not have an errorx type, returns false.
+// For an error that does not have an errorx type, returns false unless it wraps another error of errorx type.
 func IsOfType(err error, t *Type) bool {
 	e := burrowForTyped(err)
 	return e != nil && e.IsOfType(t)
@@ -16,6 +16,7 @@ func IsOfType(err error, t *Type) bool {
 // IsOfType is a proper type check for an errorx-based errors.
 // It takes the transparency and error types hierarchy into account,
 // so that type check against any supertype of the original cause passes.
+// It also tolerates non-errorx errors in chain if those errors support go 1.13 errors unwrap.
 func (e *Error) IsOfType(t *Type) bool {
 	cause := e
 	for cause != nil {

--- a/error_113_test.go
+++ b/error_113_test.go
@@ -4,6 +4,7 @@ package errorx
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -101,5 +102,19 @@ func TestErrorIs(t *testing.T) {
 	t.Run("DecorateForeign", func(t *testing.T) {
 		err := Decorate(io.EOF, "")
 		require.True(t, errors.Is(err, io.EOF))
+	})
+}
+
+func TestErrorsAndErrorx(t *testing.T) {
+	t.Run("DecoratedForeign", func(t *testing.T) {
+		err := fmt.Errorf("error test: %w", testType.NewWithNoMessage())
+		require.True(t, errors.Is(err, testType.NewWithNoMessage()))
+		require.True(t, IsOfType(err, testType))
+	})
+
+	t.Run("LayeredDecorate", func(t *testing.T) {
+		err := Decorate(fmt.Errorf("error test: %w", testType.NewWithNoMessage()), "test")
+		require.True(t, errors.Is(err, testType.NewWithNoMessage()))
+		require.True(t, IsOfType(err, testType))
 	})
 }

--- a/error_113_test.go
+++ b/error_113_test.go
@@ -117,4 +117,9 @@ func TestErrorsAndErrorx(t *testing.T) {
 		require.True(t, errors.Is(err, testType.NewWithNoMessage()))
 		require.True(t, IsOfType(err, testType))
 	})
+
+	t.Run("LayeredDecorateAgain", func(t *testing.T) {
+		err := fmt.Errorf("error test: %w", Decorate(io.EOF, "test"))
+		require.True(t, errors.Is(err, io.EOF))
+	})
 }

--- a/error_113_test.go
+++ b/error_113_test.go
@@ -122,4 +122,10 @@ func TestErrorsAndErrorx(t *testing.T) {
 		err := fmt.Errorf("error test: %w", Decorate(io.EOF, "test"))
 		require.True(t, errors.Is(err, io.EOF))
 	})
+
+	t.Run("Wrap", func(t *testing.T) {
+		err := fmt.Errorf("error test: %w", testType.Wrap(io.EOF, "test"))
+		require.False(t, errors.Is(err, io.EOF))
+		require.True(t, errors.Is(err, testType.NewWithNoMessage()))
+	})
 }

--- a/type.go
+++ b/type.go
@@ -95,6 +95,14 @@ func (t *Type) HasTrait(key Trait) bool {
 	return ok
 }
 
+// IsOfType is a type check for errors.
+// Returns true either if both are of exactly the same type, or if the same is true for one of current type's ancestors.
+// Go 1.12 and below: for an error that does not have an errorx type, returns false.
+// Go 1.13 and above: for an error that does not have an errorx type, returns false unless it wraps another error of errorx type.
+func IsOfType(err error, t *Type) bool {
+	return isOfType(err, t)
+}
+
 // Supertype returns a parent type, if present.
 func (t *Type) Supertype() *Type {
 	return t.parent

--- a/type.go
+++ b/type.go
@@ -95,14 +95,6 @@ func (t *Type) HasTrait(key Trait) bool {
 	return ok
 }
 
-// IsOfType is a type check for errors.
-// Returns true either if both are of exactly the same type, or if the same is true for one of current type's ancestors.
-// For an error that does not have an errorx type, returns false.
-func IsOfType(err error, t *Type) bool {
-	e := Cast(err)
-	return e != nil && e.IsOfType(t)
-}
-
 // Supertype returns a parent type, if present.
 func (t *Type) Supertype() *Type {
 	return t.parent


### PR DESCRIPTION
The only hiccup here is that code for earlier versions must remain unchanged, it doesn't look all that pretty in source code. 
Also, I could use any ideas for more tests. 