### PR TITLE
Set get frames public

### DIFF
--- a/error.go
+++ b/error.go
@@ -170,9 +170,9 @@ func (e *Error) Unwrap() error {
 // Format implements the Formatter interface.
 // Supported verbs:
 //
-// 		%s		simple message output
-// 		%v		same as %s
-// 		%+v		full output complete with a stack trace
+//	%s		simple message output
+//	%v		same as %s
+//	%+v		full output complete with a stack trace
 //
 // In is nearly always preferable to use %+v format.
 // If a stack trace is not required, it should be omitted at the moment of creation rather in formatting.
@@ -187,6 +187,20 @@ func (e *Error) Format(s fmt.State, verb rune) {
 	case 's':
 		_, _ = io.WriteString(s, message)
 	}
+}
+
+// GetFrames exports stacktrace as frame slice.
+func (e *Error) GetFrames() []Frame {
+	if e.stackTrace == nil {
+		return nil
+	}
+
+	pc, _ := e.stackTrace.deduplicateFramesWithCause()
+	if len(pc) == 0 {
+		return nil
+	}
+
+	return frameHelperSingleton.GetFrames(pc)
 }
 
 // Error implements the error interface.

--- a/stackframe.go
+++ b/stackframe.go
@@ -4,7 +4,7 @@ import (
 	"runtime"
 )
 
-type frame interface {
+type Frame interface {
 	Function() string
 	File() string
 	Line() int
@@ -31,9 +31,9 @@ func (f *defaultFrame) Line() int {
 	return f.frame.Line
 }
 
-func (c *frameHelper) GetFrames(pcs []uintptr) []frame {
+func (c *frameHelper) GetFrames(pcs []uintptr) []Frame {
 	frames := runtime.CallersFrames(pcs[:])
-	result := make([]frame, 0, len(pcs))
+	result := make([]Frame, 0, len(pcs))
 
 	var rawFrame runtime.Frame
 	next := true


### PR DESCRIPTION
In our applications, we catch all errors in our webservices and our batches and create [sentry issues](https://sentry.io/welcome/) with the errorx stacktrace.

```golang
errxFrames := errx.GetFrames()
framesLen := len(errxFrames)
sentryFrames := make([]sentry.Frame, framesLen)
for i, errxFrame := range errxFrames {
	sentryFrames[framesLen-i-1] = convertFrame(errxFrame)
}

func convertFrame(frame errorx.Frame) sentry.Frame {
	return sentry.Frame{
		Filename: frame.File(),
		Function: frame.Function(),
		Lineno:   frame.Line(),
	}
}
```