### PR TITLE
Respect TypeModifierOmitStackTrace in Builder

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -2,6 +2,7 @@ package errorx
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,4 +20,39 @@ func TestBuilderTransparency(t *testing.T) {
 		require.False(t, err.IsOfType(testType))
 		require.NotEqual(t, testType, err.Type())
 	})
+}
+
+func testBuilderRespectsNoStackTraceMarkerFrame() error {
+	return testType.NewWithNoMessage()
+}
+
+func TestBuilderRespectsNoStackTrace(t *testing.T) {
+	wrapperErrorTypes := []*Type{testTypeSilent, testTypeSilentTransparent}
+
+	for _, et := range wrapperErrorTypes {
+		t.Run(et.String(), func(t *testing.T) {
+			t.Run("Naked", func(t *testing.T) {
+				err := NewErrorBuilder(et).
+					WithCause(errors.New("naked error")).
+					Create()
+				require.Nil(t, err.stackTrace)
+			})
+
+			t.Run("WithoutStacktrace", func(t *testing.T) {
+				err := NewErrorBuilder(et).
+					WithCause(testTypeSilent.NewWithNoMessage()).
+					Create()
+				require.Nil(t, err.stackTrace)
+			})
+
+			t.Run("WithStacktrace", func(t *testing.T) {
+				cause := testBuilderRespectsNoStackTraceMarkerFrame()
+				err := NewErrorBuilder(et).
+					WithCause(cause).
+					Create()
+				require.Same(t, err.stackTrace, Cast(cause).stackTrace)
+				require.Contains(t, fmt.Sprintf("%+v", err), "testBuilderRespectsNoStackTraceMarkerFrame")
+			})
+		})
+	}
 }

--- a/error_test.go
+++ b/error_test.go
@@ -9,14 +9,15 @@ import (
 )
 
 var (
-	testNamespace       = NewNamespace("foo")
-	testType            = testNamespace.NewType("bar")
-	testTypeSilent      = testType.NewSubtype("silent").ApplyModifiers(TypeModifierOmitStackTrace)
-	testTypeTransparent = testType.NewSubtype("transparent").ApplyModifiers(TypeModifierTransparent)
-	testSubtype0        = testType.NewSubtype("internal")
-	testSubtype1        = testSubtype0.NewSubtype("wat")
-	testTypeBar1        = testNamespace.NewType("bar1")
-	testTypeBar2        = testNamespace.NewType("bar2")
+	testNamespace             = NewNamespace("foo")
+	testType                  = testNamespace.NewType("bar")
+	testTypeSilent            = testType.NewSubtype("silent").ApplyModifiers(TypeModifierOmitStackTrace)
+	testTypeTransparent       = testType.NewSubtype("transparent").ApplyModifiers(TypeModifierTransparent)
+	testTypeSilentTransparent = testType.NewSubtype("silent_transparent").ApplyModifiers(TypeModifierTransparent, TypeModifierOmitStackTrace)
+	testSubtype0              = testType.NewSubtype("internal")
+	testSubtype1              = testSubtype0.NewSubtype("wat")
+	testTypeBar1              = testNamespace.NewType("bar1")
+	testTypeBar2              = testNamespace.NewType("bar2")
 )
 
 func TestError(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.11
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,12 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Previous implementation of `WithCause` method didn't respect the `TypeModifierOmitStackTrace` modifier. A stack trace was erroneously collected if the error that was passed to `WithCause` didn't have stack trace.