### PR TITLE
Drop ancient Go versions and add modern ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,11 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.8, 1.9, '1.10', 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18]
+        go: [1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19, '1.20', 1.21, 1.22, 1.23]
 
     steps:
 
-    - name: Checkout to GOPATH
-      if: ${{ matrix.go == '1.8' || matrix.go == '1.9' || matrix.go == '1.10' }}
-      uses: actions/checkout@v2
-      with:
-        path: go/src/github.com/${{ github.repository }}
-
-    - name: Checkout with no GOPATH
-      if: ${{ matrix.go != '1.8' && matrix.go != '1.9' && matrix.go != '1.10' }}
+    - name: Checkout
       uses: actions/checkout@v2
 
     - name: Set up Go ${{ matrix.go }}
@@ -28,19 +21,6 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
-    - name: "Setup dependencies"
-      if: ${{ matrix.go == '1.8' || matrix.go == '1.9' || matrix.go == '1.10' }}
-      run: go get -t ./... && cd $GOPATH/src/github.com/stretchr/testify/ && git checkout v1.2.2 && cd - && pwd
-      env:
-        GOPATH: /home/runner/work/errorx/errorx/go
-
-    - name: Build no modules
-      if: ${{ matrix.go == '1.8' || matrix.go == '1.9' || matrix.go == '1.10' }}
-      run: cd go/src/github.com/${{ github.repository }} && go test -v ./...
-      env:
-        GOPATH: /home/runner/work/errorx/errorx/go
-
-    - name: Build with modules
-      if: ${{ matrix.go != '1.8' && matrix.go != '1.9' && matrix.go != '1.10' }}
+    - name: Build
       run: go test -v ./...
 


### PR DESCRIPTION
Updating `github.com/stretchr/testify` in #43 requires too much work due to ancient Go versions support. I'm going to drop everything below 1.11 and nobody would miss them. I've added all Go versions up to 1.23 to compensate the loss a little bit.